### PR TITLE
Support link to specific line number on Bitbucket

### DIFF
--- a/src/org/salesforce/apexdoc/FileManager.java
+++ b/src/org/salesforce/apexdoc/FileManager.java
@@ -85,8 +85,16 @@ public class FileManager {
     }
 
     private String strLinkfromModel(ApexModel model, String strClassName, String hostedSourceURL) {
-        return "<a target='_blank' class='hostedSourceLink' href='" + hostedSourceURL + strClassName + ".cls#L"
-                + model.getInameLine() + "'>";
+        String fileName = strClassName + ".cls";
+        String lineParam;
+        if (hostedSourceURL.startsWith("https://bitbucket.org/")) {
+            // for Bitbucket
+            lineParam = "?#" + fileName + '-' + model.getInameLine();
+        } else {
+            lineParam = "#L" + model.getInameLine();
+        }
+        return "<a target='_blank' class='hostedSourceLink' href='" + hostedSourceURL + fileName
+                + lineParam + "'>";
     }
 
     private String strHTMLScopingPanel() {


### PR DESCRIPTION
Links to specific line number on Bitbucket repository are not working, so I fixed.

Here's a sample build command:
```
$ java -jar apexdoc.jar -s 'src/classes' -g 'https://bitbucket.org/user_name/repository_name/src/master/src/classes/'
```

#Sorry, I'm not good at English.
