### PR TITLE
Fixed <code> tag not rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In order for ApexDoc to identify class methods, the method line must contain an 
 | @description | one or more lines that provide an overview of the method|
 | @param *param name* | a description of what the parameter does|
 | @return | a description of the return value from the method|
-| @example | Example code usage. This will be wrapped in <code> tags to preserve whitespace|
+| @example | Example code usage. This will be wrapped in `<code>` tags to preserve whitespace|
 Example
 ```
     /*******************************************************************************************************


### PR DESCRIPTION
On line 87 guide refers to "code" tag to use in order to preserve whitespaces in documentation examples. This tag is processed by Markdown engine as a tag, not as text, so that it should be wrapped in back-ticks.